### PR TITLE
Accommodate Multiple File Uploads & Views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore DB files
+/db/*
+**/db.json
+# Ignore executable
+**/shupload

--- a/src/DataBaseEntry.go
+++ b/src/DataBaseEntry.go
@@ -19,10 +19,11 @@ along with shupload.  If not, see <https://www.gnu.org/licenses/>.
 package main
 
 import (
-  "time"
+	"time"
 )
 
 type DataBaseEntry struct {
+	Key string
   CreationTime time.Time `json:"time"`
   Filename string `json:"filename"`
   Mimetype string

--- a/src/DataBase_filestore.go
+++ b/src/DataBase_filestore.go
@@ -27,6 +27,8 @@ import (
 	"path/filepath"
 
 	//
+
+	"fmt"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -85,7 +87,7 @@ func NewMetaDriver(db string) (m *MetaDriver, err error) {
 func (m *MetaDriver) Get(key string) (entries []DataBaseEntry, err error) {
   entries, ok := m.db[key]
   if !ok {
-    // TODO: return error (does not exist)
+		err = fmt.Errorf("file not found: %s", key)
   }
   return
 }
@@ -132,6 +134,7 @@ func (d *DataBase) CreateEntries(h []*multipart.FileHeader) (entries []DataBaseE
 	for i, header := range h {
 		entryKey := d.GetKey()
 		if (len(header.Filename) > AppInstance.Config.MaxFilenameLength) {
+			err = fmt.Errorf("file name length limit exceeded: %d > %d", len(header.Filename), AppInstance.Config.MaxFilenameLength)
 			return
 		}
 	
@@ -140,6 +143,7 @@ func (d *DataBase) CreateEntries(h []*multipart.FileHeader) (entries []DataBaseE
 		kbSize := float64(fileSize) / float64(kbLimit)
 	
 		if (int(kbSize) > AppInstance.Config.MaxFileSize) {
+			err = fmt.Errorf("file size limit exceeded: %d > %d", int(kbSize), AppInstance.Config.MaxFileSize)
 			return
 		}
 	
@@ -149,6 +153,7 @@ func (d *DataBase) CreateEntries(h []*multipart.FileHeader) (entries []DataBaseE
 			Filename: header.Filename,
 			Mimetype: mime.TypeByExtension(filepath.Ext(header.Filename)),
 		}
+
 		entries[i] = entry
 		file, _ := header.Open()
 		err = d.fileDB.Write(entryKey, file)

--- a/src/DataBase_filestore.go
+++ b/src/DataBase_filestore.go
@@ -38,94 +38,107 @@ import (
 )
 
 type FileDriver struct {
-  root string
+	root string
 }
+
 func NewFileDriver(db string) (f *FileDriver, err error) {
-  f = &FileDriver{
-    root: db,
-  }
-  if _, err = os.Stat(db); os.IsNotExist(err) {
-    err = os.Mkdir(db, 0777)
-  }
-  return
+	f = &FileDriver{
+		root: db,
+	}
+	if _, err = os.Stat(db); os.IsNotExist(err) {
+		err = os.Mkdir(db, 0777)
+	}
+	return
 }
 func (fd *FileDriver) Write(key string, r io.ReadCloser) (err error) {
-  f, err := os.Create(path.Join(fd.root, key))
-  if err != nil {
-    return
-  }
-  _, err = io.Copy(f, r)
-  if err != nil {
-    return
-  }
-  return
+	f, err := os.Create(path.Join(fd.root, key))
+	if err != nil {
+		return
+	}
+	_, err = io.Copy(f, r)
+	if err != nil {
+		return
+	}
+	return
 }
 func (fd *FileDriver) ReadStream(key string) (r io.ReadSeeker, err error) {
-  r, err = os.Open(path.Join(fd.root, key))
-  return
+	r, err = os.Open(path.Join(fd.root, key))
+	return
 }
 
 type MetaDriver struct {
-  root string
-  file *os.File
-  db map[string][]DataBaseEntry
+	root string
+	file *os.File
+	db   map[string][]DataBaseEntry
 }
-func NewMetaDriver(db string) (m *MetaDriver, err error) {
-  m = &MetaDriver{
-    root: db,
-  }
-  m.file, err = os.OpenFile(m.root, os.O_RDWR|os.O_CREATE, 0644)
-  if err != nil {
-    return
-  }
-  bytes, _ := ioutil.ReadAll(m.file)
 
-  m.db = make(map[string][]DataBaseEntry)
-  json.Unmarshal([]byte(bytes), &m.db)
-  return
+func NewMetaDriver(db string) (m *MetaDriver, err error) {
+	m = &MetaDriver{
+		root: db,
+	}
+	m.file, err = os.OpenFile(m.root, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return
+	}
+	bytes, _ := ioutil.ReadAll(m.file)
+
+	// Let's see if the database is olde and needs to be upgraded.
+	oldDB := make(map[string]DataBaseEntry)
+	if err := json.Unmarshal([]byte(bytes), &oldDB); err == nil {
+		m.db = make(map[string][]DataBaseEntry)
+		for k, e := range oldDB {
+			m.db[k] = []DataBaseEntry{e}
+		}
+		err = m.Sync()
+	} else {
+		m.db = make(map[string][]DataBaseEntry)
+		json.Unmarshal([]byte(bytes), &m.db)
+	}
+	return
 }
 func (m *MetaDriver) Get(key string) (entries []DataBaseEntry, err error) {
-  entries, ok := m.db[key]
-  if !ok {
+	entries, ok := m.db[key]
+	if !ok {
 		err = fmt.Errorf("file not found: %s", key)
-  }
-  return
+	}
+	return
 }
 func (m *MetaDriver) Write(key string, entries []DataBaseEntry) (err error) {
-  m.db[key] = entries
-  err = m.Sync()
-  return
+	m.db[key] = entries
+	err = m.Sync()
+	return
 }
 func (m *MetaDriver) Remove(key string) (err error) {
-  delete(m.db, key)
-  err = m.Sync()
-  return
+	delete(m.db, key)
+	err = m.Sync()
+	return
 }
 func (m *MetaDriver) Sync() (err error) {
-  var data []byte
-  data, err = json.Marshal(m.db)
-  if err != nil {
-    return
-  }
-  _, err = m.file.Seek(0, 0)
-  if err != nil {
-    return
-  }
-  m.file.Write(data)
-  return
+	var data []byte
+	data, err = json.Marshal(m.db)
+	if err != nil {
+		return
+	}
+	_, err = m.file.Seek(0, 0)
+	if err != nil {
+		return
+	}
+	m.file.Write(data)
+	return
 }
 
 type DataBase struct {
-  fileDB *FileDriver
-  metaDB *MetaDriver
+	fileDB *FileDriver
+	metaDB *MetaDriver
 }
+
 func (d *DataBase) Init() (err error) {
-  d.fileDB, err = NewFileDriver(AppInstance.Config.DatabaseLocation)
-  if err != nil {
-    return
-  }
-  d.metaDB, err = NewMetaDriver(AppInstance.Config.DatabaseLocation+".json")
-  return
+	d.fileDB, err = NewFileDriver(AppInstance.Config.DatabaseLocation)
+	if err != nil {
+		return
+	}
+	d.metaDB, err = NewMetaDriver(AppInstance.Config.DatabaseLocation + ".json")
+	return
 }
 func (d *DataBase) CreateEntries(h []*multipart.FileHeader) (entries []DataBaseEntry, key string, err error) {
 	entries = make([]DataBaseEntry, len(h))
@@ -133,47 +146,47 @@ func (d *DataBase) CreateEntries(h []*multipart.FileHeader) (entries []DataBaseE
 
 	for i, header := range h {
 		entryKey := d.GetKey()
-		if (len(header.Filename) > AppInstance.Config.MaxFilenameLength) {
+		if len(header.Filename) > AppInstance.Config.MaxFilenameLength {
 			err = fmt.Errorf("file name length limit exceeded: %d > %d", len(header.Filename), AppInstance.Config.MaxFilenameLength)
 			return
 		}
-	
+
 		var kbLimit int64 = 1024
 		var fileSize int64 = header.Size
 		kbSize := float64(fileSize) / float64(kbLimit)
-	
-		if (int(kbSize) > AppInstance.Config.MaxFileSize) {
+
+		if int(kbSize) > AppInstance.Config.MaxFileSize {
 			err = fmt.Errorf("file size limit exceeded: %d > %d", int(kbSize), AppInstance.Config.MaxFileSize)
 			return
 		}
-	
+
 		entry := DataBaseEntry{
-			Key: entryKey,
+			Key:          entryKey,
 			CreationTime: time.Now(),
-			Filename: header.Filename,
-			Mimetype: mime.TypeByExtension(filepath.Ext(header.Filename)),
+			Filename:     header.Filename,
+			Mimetype:     mime.TypeByExtension(filepath.Ext(header.Filename)),
 		}
 
 		entries[i] = entry
 		file, _ := header.Open()
 		err = d.fileDB.Write(entryKey, file)
 	}
-  err = d.metaDB.Write(key, entries)
-  if err != nil {
-    return
-  }
+	err = d.metaDB.Write(key, entries)
+	if err != nil {
+		return
+	}
 
-  return
+	return
 }
 func (d *DataBase) GetEntries(key string) (entries []DataBaseEntry, err error) {
-  entries, err = d.metaDB.Get(key)
-  return
+	entries, err = d.metaDB.Get(key)
+	return
 }
 func (d *DataBase) GetEntryStream(key string) (r io.ReadSeeker, err error) {
-  r, err = d.fileDB.ReadStream(key)
-  return
+	r, err = d.fileDB.ReadStream(key)
+	return
 }
 func (d *DataBase) KeyExists(key string) bool {
-  return false
-  //return d.fileDB.Has(key)
+	return false
+	//return d.fileDB.Has(key)
 }

--- a/src/UploadHandler.go
+++ b/src/UploadHandler.go
@@ -47,7 +47,7 @@ func (h *UploadHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		_, key, err := AppInstance.DataBase.CreateEntries(fileHandlers)
 		if err != nil {
 			log.Print(err)
-			http.Error(res, "Failed to create entry", http.StatusInternalServerError)
+			http.Error(res, "Failed to create entries", http.StatusInternalServerError)
 			return
 		}
 

--- a/src/UploadHandler.go
+++ b/src/UploadHandler.go
@@ -19,11 +19,11 @@ along with shupload.  If not, see <https://www.gnu.org/licenses/>.
 package main
 
 import (
-  "net/http"
-  "html/template"
-  "log"
-  "io/ioutil"
-  "fmt"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"log"
+	"net/http"
 )
 
 
@@ -42,17 +42,15 @@ func (h *UploadHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
     }
   } else if (req.Method == "POST") {
     req.ParseMultipartForm(32 << 20)
-    file, handler, err := req.FormFile("file")
-    if err != nil {
-      log.Print(err)
-      return
-    }
-    _, key, err := AppInstance.DataBase.CreateEntry(file, handler)
-    if err != nil {
-      log.Print(err)
-      http.Error(res, "Failed to create entry", http.StatusInternalServerError)
-      return
-    }
+		fileHandlers := req.MultipartForm.File["file"]
+
+		_, key, err := AppInstance.DataBase.CreateEntries(fileHandlers)
+		if err != nil {
+			log.Print(err)
+			http.Error(res, "Failed to create entry", http.StatusInternalServerError)
+			return
+		}
+
     http.Redirect(res, req, key, http.StatusSeeOther)
   } else {
     http.Error(res, "Method Not Allowed", http.StatusMethodNotAllowed)

--- a/src/ViewHandler.go
+++ b/src/ViewHandler.go
@@ -31,6 +31,19 @@ import (
 
 type ViewHandler struct {
 	template *template.Template
+	multipleTemplate *template.Template
+}
+type FileMetadata struct {
+	URI          string
+	Filename     string
+	Mimetype     string
+	Entryname    string
+	CreationTime string
+}
+type ResponseData struct {
+	Key  string
+	Files []FileMetadata
+	CreationTime string
 }
 
 func (h *ViewHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
@@ -39,74 +52,93 @@ func (h *ViewHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	key, req.URL.Path = ShiftPath(req.URL.Path)
 	filename, req.URL.Path = ShiftPath(req.URL.Path)
 
-	entry, err := AppInstance.DataBase.GetEntry(key)
+	entries, err := AppInstance.DataBase.GetEntries(key)
+	responseData := ResponseData {
+		Key: key,
+	  Files: []FileMetadata{},
+		CreationTime: entries[0].CreationTime.Format("2006-01-02 15:04:05"),
+	}
 	if err != nil {
 		// TODO: 404 redirect!
-		http.Error(res, "No such file!", http.StatusNotFound)
+		http.Error(res, "No such files!", http.StatusNotFound)
 		return
 	}
+	for _, entry := range entries {
+		if filename == "" {
+			// If we're getting the metadata for an upload
+			data := FileMetadata {
+				URI:          path.Join(key, entry.Filename),
+				Filename:     entry.Filename,
+				Mimetype:     entry.Mimetype,
+				Entryname:    key,
+				CreationTime: entry.CreationTime.Format("2006-01-02 15:04:05"),
+			}
+			responseData.Files = append(responseData.Files, data)
+			if err != nil {
+				http.Error(res, "Failed to execute template", http.StatusInternalServerError)
+				log.Print(err)
+				return
+			}
+		} else if filename == entry.Filename {
+			// If we're directly accessing a specific file
+			data, err := AppInstance.DataBase.GetEntryStream(entry.Key)
+			if err != nil {
+				http.Error(res, "Data file missing", http.StatusInternalServerError)
+				return
+			}
+			// Get our length
+			length, err := data.Seek(0, io.SeekEnd)
+			if err != nil {
+				http.Error(res, "Error while seeking to end of data", http.StatusInternalServerError)
+				return
+			}
+			_, err = data.Seek(0, 0)
+			if err != nil {
+				http.Error(res, "Error while seeking to start of data", http.StatusInternalServerError)
+				return
+			}
+			res.Header().Set("Content-Disposition", "attachment; filename="+filename)
+			res.Header().Set("Content-Type", entry.Mimetype)
+			res.Header().Set("Content-Length", strconv.FormatInt(length, 10))
+			io.Copy(res, data)
+		}
+	}
 
-	if filename == "" {
-		data := struct {
-			URI          string
-			Filename     string
-			Mimetype     string
-			Entryname    string
-			CreationTime string
-		}{
-			URI:          path.Join(key, entry.Filename),
-			Filename:     entry.Filename,
-			Mimetype:     entry.Mimetype,
-			Entryname:    key,
-			CreationTime: entry.CreationTime.Format("2006-01-02 15:04:05"),
-		}
-		err := h.template.Execute(res, data)
-		if err != nil {
-			http.Error(res, "Failed to execute template", http.StatusInternalServerError)
-			log.Print(err)
-			return
-		}
-	} else if filename == entry.Filename {
-		data, err := AppInstance.DataBase.GetEntryStream(key)
-		if err != nil {
-			http.Error(res, "Data file missing", http.StatusInternalServerError)
-			return
-		}
-		// Get our length
-		length, err := data.Seek(0, io.SeekEnd)
-		if err != nil {
-			http.Error(res, "Error while seeking to end of data", http.StatusInternalServerError)
-			return
-		}
-		_, err = data.Seek(0, 0)
-		if err != nil {
-			http.Error(res, "Error while seeking to start of data", http.StatusInternalServerError)
-			return
-		}
-
-		res.Header().Set("Content-Disposition", "attachment; filename="+filename)
-		res.Header().Set("Content-Type", entry.Mimetype)
-		res.Header().Set("Content-Length", strconv.FormatInt(length, 10))
-		io.Copy(res, data)
-	} else {
-		http.Error(res, "wat u doin", http.StatusBadRequest)
+	// If we've populated the response data, render the template
+	//  -- These templates could probably be combined and just one used
+	if len(responseData.Files) > 1 {
+		h.multipleTemplate.Execute(res, responseData)
+	} else if len(responseData.Files) > 0 {
+		h.template.Execute(res, responseData.Files[0])
 	}
 }
 
 func (h *ViewHandler) LoadTemplate() error {
-	b, err := ioutil.ReadFile("templates/view.tmpl")
+	// These templates could probably be combined and just one used
+	viewTemplate, err := ioutil.ReadFile("templates/view.tmpl")
 	if err != nil {
 		return err
 	}
+	multipleTemplate, err := ioutil.ReadFile("templates/viewMultiple.tmpl")
+	if err != nil {
+		return err
+	}
+	
 	h.template, err = template.New("view").Funcs(template.FuncMap{
 		"regexMatch": func(r, s string) bool {
 			matched, _ := regexp.Match(r, []byte(s))
-			if matched {
-				return true
-			}
-			return false
+			return matched
 		},
-	}).Parse(string(b))
+	}).Parse(string(viewTemplate))
+	if err != nil {
+		return err
+	}
+	h.multipleTemplate, err = template.New("viewMultiple").Funcs(template.FuncMap{
+		"regexMatch": func(r, s string) bool {
+			matched, _ := regexp.Match(r, []byte(s))
+			return matched
+		},
+	}).Parse(string(multipleTemplate))
 	if err != nil {
 		return err
 	}

--- a/static/shupload.js
+++ b/static/shupload.js
@@ -263,16 +263,15 @@ let shupload = (function () {
         },
         view: () => {
           return m("textarea.Clipboard", {
-            placeholder: "Use ⌃v or ⌘v to paste an image here.",
+            placeholder: "Use ⌃v or ⌘v to paste a file or files here.",
             onpaste: (e) => {
               if (e.clipboardData && e.clipboardData.items) {
-                let items = e.clipboardData.items
-                for (let i = 0; i < items.length; i++) {
-                  if (items[i].type.indexOf('image') !== -1) {
-                    sendFile(items[i].getAsFile())
-                    e.preventDefault();
-                  }
-                }
+                const items = e.clipboardData.items
+                const files = []
+                for(const item of items)
+                  files.push(item.getAsFile())
+                sendFile(files)
+                e.preventDefault()
               }
             }
           })

--- a/static/shupload.js
+++ b/static/shupload.js
@@ -42,7 +42,7 @@ let shupload = (function () {
     let inp = document.createElement('input')
     inp.setAttribute('type', 'file')
     inp.setAttribute('accept', 'image/*')
-    inp.setAttribute('multiple', true)
+    inp.multiple = true
     inp.style = "display:none";
     inp.addEventListener('change', (e) => {
       sendFile(e.target.files)

--- a/static/shupload.js
+++ b/static/shupload.js
@@ -518,7 +518,7 @@ let shupload = (function () {
                     },
                     title: "Copy Link to Clipboard"
                   }, '🔗'),
-                  m('.Label', view.Filename),
+                  m('.Label', decodeURIComponent(view.Filename)),
                   m('a', {
                     href: view.Entryname + '/' + view.Filename,
                     title: "Download file"

--- a/static/shupload.js
+++ b/static/shupload.js
@@ -35,27 +35,46 @@ This file is an optional JavaScript enhancement for shupload. It provides:
 FIXME: This is pretty weird and messy!
 TODO: actual comments
 */
-let shupload =  (function() {
+
+let shupload = (function () {
+  // Method for presenting the user with a file select prompt
+  function selectFile() {
+    let inp = document.createElement('input')
+    inp.setAttribute('type', 'file')
+    inp.setAttribute('accept', 'image/*')
+    inp.setAttribute('multiple', true)
+    inp.style = "display:none";
+    inp.addEventListener('change', (e) => {
+      console.log(e.target.files);
+      sendFile(e.target.files)
+      inp.parentNode.removeChild(inp)
+    })
+    // element must exist for iOS so we add it
+    document.body.appendChild(inp)
+    inp.click()
+  }
+
   // Canvas toBlob Polyfill for Edge, courtesy of https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#Polyfill
-	if (!HTMLCanvasElement.prototype.toBlob) {
-	  Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
-	    value: function (callback, type, quality) {
-	      var dataURL = this.toDataURL(type, quality).split(',')[1]
-	      setTimeout(function() {
-	        var binStr = atob( dataURL ),
-	            len = binStr.length,
-	            arr = new Uint8Array(len)
-	        for (var i = 0; i < len; i++ ) {
-	          arr[i] = binStr.charCodeAt(i)
-	        }
-	        callback( new Blob( [arr], {type: type || 'image/png'} ) )
-	      });
-	    }
-	  });
-	}
+  if (!HTMLCanvasElement.prototype.toBlob) {
+    Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
+      value: function (callback, type, quality) {
+        var dataURL = this.toDataURL(type, quality).split(',')[1]
+        setTimeout(function () {
+          var binStr = atob(dataURL),
+            len = binStr.length,
+            arr = new Uint8Array(len)
+          for (var i = 0; i < len; i++) {
+            arr[i] = binStr.charCodeAt(i)
+          }
+          callback(new Blob([arr], { type: type || 'image/png' }))
+        });
+      }
+    });
+  }
   // Offscreen canvas and context
   let Canvas = document.createElement('canvas')
   let Context = Canvas.getContext('2d')
+
   // Individual sections -- generates to tabs and tab contents
   let Sections = [
     { name: "🖼️ File",
@@ -95,11 +114,11 @@ let shupload =  (function() {
               },
               autoplay: true
             }),
-            (pv.state.pictureTaken ? 
+            (pv.state.pictureTaken ?
               m(".Preview", {
-                style: "background-image: url("+Canvas.toDataURL()+");"
+                style: "background-image: url(" + Canvas.toDataURL() + ");"
               })
-            :
+              :
               null),
             m(".Buttons",
               (pv.state.pictureTaken ?
@@ -118,13 +137,13 @@ let shupload =  (function() {
                   }, "↩ Retake"),
                   m(".Button", {
                     onclick: () => {
-                    	Canvas.toBlob((blob) => {
-                        sendFile(blob, pv.state.filename+".png")
-                    	})
+                      Canvas.toBlob((blob) => {
+                        sendFile(blob, pv.state.filename + ".png")
+                      })
                     }
                   }, "⇪ Upload")
                 ]
-              :
+                :
                 m(".Button", {
                   onclick: () => {
                     pv.state.pictureTaken = true
@@ -177,11 +196,11 @@ let shupload =  (function() {
               },
               autoplay: true
             }),
-            (pv.state.pictureTaken ? 
+            (pv.state.pictureTaken ?
               m(".Preview", {
-                style: "background-image: url("+Canvas.toDataURL()+");"
+                style: "background-image: url(" + Canvas.toDataURL() + ");"
               })
-            :
+              :
               null),
             m(".Buttons",
               (pv.state.pictureTaken ?
@@ -212,13 +231,13 @@ let shupload =  (function() {
                   }, "↩ Retake"),
                   m(".Button", {
                     onclick: () => {
-                    	Canvas.toBlob((blob) => {
-                        sendFile(blob, pv.state.filename+".png")
-                    	})
+                      Canvas.toBlob((blob) => {
+                        sendFile(blob, pv.state.filename + ".png")
+                      })
                     }
                   }, "⇪ Upload")
                 ]
-              :
+                :
                 m(".Button", {
                   onclick: () => {
                     pv.state.pictureTaken = true
@@ -258,6 +277,7 @@ let shupload =  (function() {
       }
     },
   ]
+
   // Upload Bar located at the bottom of the view
   let UploadBar = {
     StateClasses: [
@@ -281,8 +301,8 @@ let shupload =  (function() {
     RemainingTime: 0,
     TargetTime: 2500,
     UpdateTotals: (sent, total) => {
-      UploadBar.Sent = Math.round(sent/1024)
-      UploadBar.Total = Math.round(total/1024)
+      UploadBar.Sent = Math.round(sent / 1024)
+      UploadBar.Total = Math.round(total / 1024)
       UploadBar.Progress = (sent / total) * 100
     },
     Component: {
@@ -292,17 +312,18 @@ let shupload =  (function() {
           UploadBar.State == UploadBar.States.Idle ?
             "Idle"
             :
-          UploadBar.State == UploadBar.States.Sending ?
-            "Sent: " + (UploadBar.Sent + " / " + UploadBar.Total + " kB")
-            :
-          UploadBar.State == UploadBar.States.Errored ?
-            "Error"
-            :
-            ("Uploaded, redirecting in " + (UploadBar.RemainingTime.toFixed(1)) + "s")
+            UploadBar.State == UploadBar.States.Sending ?
+              "Sent: " + (UploadBar.Sent + " / " + UploadBar.Total + " kB")
+              :
+              UploadBar.State == UploadBar.States.Errored ?
+                "Error"
+                :
+                ("Uploaded, redirecting in " + (UploadBar.RemainingTime.toFixed(1)) + "s")
         ))
       }
     }
   }
+
   // Main state and rendering component
   let Main = {
     CurrentSection: 0,
@@ -325,7 +346,7 @@ let shupload =  (function() {
           ondrop: (e) => {
             e.stopPropagation()
             e.preventDefault()
-            sendFile(e.dataTransfer.files[0])
+            sendFile(e.dataTransfer.files)
           },
           ondragover: (e) => {
             e.stopPropagation()
@@ -348,17 +369,23 @@ let shupload =  (function() {
       }
     }
   }
+
   // Method for sending a file via POST
   function sendFile(file, filename) {
     UploadBar.State = UploadBar.States.Sending
-    let r = new XMLHttpRequest()
-    let d = new FormData()
+    const r = new XMLHttpRequest()
+    const d = new FormData()
+    const files = !file.length ? [file] : file
+
     //r.setRequestHeader('Content-type', 'multipart/form-data')
-    if (filename !== undefined) {
-      d.append('file', file, filename)
-    } else {
-      d.append('file', file)
+    for (const f of files) {
+      if (filename !== undefined) {
+        d.append('file', f, filename)
+      } else {
+        d.append('file', f)
+      }
     }
+
     r.addEventListener('load', (e) => {
       UploadBar.State = UploadBar.States.Success
       UploadBar.StartTime = new Date()
@@ -384,199 +411,218 @@ let shupload =  (function() {
     r.open('POST', '')
     r.send(d)
   }
-  // Method for presenting the user with a file select prompt
-  function selectFile() {
-    let inp = document.createElement('input')
-    inp.setAttribute('type', 'file')
-    inp.setAttribute('accept', 'image/*')
-    inp.style = "display:none";
-    inp.addEventListener('change', (e) => {
-      sendFile(e.target.files[0])
-      inp.parentNode.removeChild(inp)
-    })
-    // element must exist for iOS so we add it
-    document.body.appendChild(inp)
-    inp.click()
-  }
 
   // Status bar
   let StatusBar = {
     Component: {
       view: () => {
-        return m("#StatusBar", View.CreationTime)
+        return m("#StatusBar", Views[0].CreationTime)
       }
     }
   }
-  // View state and rendering component
-  let View = {
-    Filename: "",
-    Entryname: "",
-    Propername: "",
-    Type: "",
-    HiddenImage: document.createElement('img'),
-    TabContent: null,
-    ImageHeight: "",
-    ImageWidth: "",
-    isZoomed: false,
-    isScaled: false,
-    calculateImageSize: () => {
-      if (!View.TabContent) return
-      if (View.isZoomed) {
-        View.ImageWidth = View.HiddenImage.width
-        View.ImageHeight = View.HiddenImage.height
-        return
-      }
-      let b = View.TabContent.getBoundingClientRect()
-      let r = Math.min(b.width / View.HiddenImage.width, b.height / View.HiddenImage.height)
-      View.isScaled = r > 1 ? true : false
-      View.ImageWidth = View.HiddenImage.width * r
-      View.ImageHeight = View.HiddenImage.height * r
-      m.redraw()
-    },
-    Component: {
-      view: (vnode) => {
-        return m("section#Main.View", {
-        }, [
-          m("section.Tabs", [
-            m('a', {
-              href: './',
-              title: "Return to Upload"
-            }, m('section.Tab', '↩')),
-            m('.Label', {
-              style: "flex: 1;"
-            }, [
-              m('a', {
-                href: View.Entryname,
-                onclick: (e) => {
-                  e.preventDefault()
-                  // Attempt to use modern clipboard functionality
-                  if (navigator.clipboard) {
-                    navigator.clipboard.writeText(e.target.href).then(() => {
-                    }, (err) => {
-                      console.log(err)
-                      alert(err)
-                    })
-                  // Otherwise use THE CLASSIC.
-                  } else {
-                    let link = document.createElement('a')
-                    link.href = View.Entryname
-                    let Textarea = document.createElement('textarea')
-                    Textarea.value = link.href
-                    document.body.appendChild(Textarea)
-                    Textarea.focus()
-                    Textarea.select()
-                    try {
-                      let success = document.execCommand('copy')
-                      if (!success) {
-                        alert('could not copy to clipboard')
-                      }
-                    } catch (err) {
-                      console.log(err)
-                      alert(err)
-                    }
-                    document.body.removeChild(Textarea)
-                  }
-                },
-                title: "Copy Link to Clipboard"
-              }, '🔗'),
-              m('.Label', View.Propername),
-              m('a', {
-                href: View.Entryname+'/'+View.Filename,
-                title: "Download file"
-              }, '⬇')
-            ])
-          ]),
-          m("section.TabContent" + (View.isScaled ? (".Scaled" + (View.isZoomed ? ".ZoomedOut" : ".ZoomedIn")) : (View.isZoomed ? ".ZoomedIn" : ".ZoomedOut")),
-            { 
-              oncreate: (vnode) => {
-                View.TabContent = vnode.dom
-              }
-            },
-            [
-            View.Type === "image" ? 
-              m('.DataContainer'+ (View.ImageZoom ? '.Zoomed' : ''), {
-                style: "width: "+View.ImageWidth+"px;height: "+View.ImageHeight+"px;background-image: url(" + View.Entryname + "/" + View.Filename + ");",
-                onclick: e => {
-                  e.preventDefault()
-                  View.isZoomed = !View.isZoomed
-                  View.calculateImageSize()
-                }
-              })
-            : View.Type === "audio" ?
-              m('.DataContainer', 
-                m('audio', {
-                  controls: true,
-                  src: View.Entryname+"/"+View.Filename,
-                })
-              )
-            : View.Type === "video" ?
-              m('.DataContainer',
-                m('video', {
-                  controls: true,
-                }, m('source', {
-                  src: View.Entryname+"/"+View.Filename,
-                  type: View.Mimetype,
-                }))
-              )
-            : m('.DataContainer', m.trust(View.DataHTML))
-          ]),
-          m(StatusBar.Component)
-        ])
-      }
-    }
-  }
-  let $ = {
-    letsGo: () => {
-      let target = document.getElementById("Container")
-      if (target.children[0].className == "View") {
-        let fpart = document.getElementById("Filename")
-        if (fpart) {
-          View.Propername = fpart.innerText
+
+  // this state and rendering component
+  const Views = [];
+  const createView = () => {
+    return {
+      Filename: "",
+      Entryname: "",
+      Propername: "",
+      Type: "",
+      HiddenImage: document.createElement('img'),
+      TabContent: null,
+      ImageHeight: "",
+      ImageWidth: "",
+      isZoomed: false,
+      isScaled: false,
+      calculateImageSize: (view) => {
+        if (!view.TabContent) return
+        if (view.isZoomed) {
+          console.log('is zoomed');
+          view.ImageWidth = view.HiddenImage.width
+          view.ImageHeight = view.HiddenImage.height
+          return
         }
+        let b = view.TabContent.getBoundingClientRect()
+        let r = Math.min(b.width / view.HiddenImage.width, b.height / view.HiddenImage.height)
+        view.isScaled = r > 1 ? true : false
+        view.ImageWidth = view.HiddenImage.width * r
+        view.ImageHeight = view.HiddenImage.height * r
+        m.redraw()
+      },
+      GetComponent: (view) => {
+        return { view: (vnode) => {
+          return m("section#Main.View", {
+          }, [
+            m("section.Tabs", [
+              m('a', {
+                href: './',
+                title: "Return to Upload"
+              }, m('section.Tab', '↩')),
+              m('.Label', {
+                style: "flex: 1;"
+              }, [
+                m('a', {
+                  href: view.Entryname,
+                  onclick: (e) => {
+                    e.preventDefault()
+                    // Attempt to use modern clipboard functionality
+                    if (navigator.clipboard) {
+                      navigator.clipboard.writeText(e.target.href).then(() => {
+                      }, (err) => {
+                        console.log(err)
+                        alert(err)
+                      })
+                      // Otherwise use THE CLASSIC.
+                    } else {
+                      let link = document.createElement('a')
+                      link.href = view.Entryname
+                      let Textarea = document.createElement('textarea')
+                      Textarea.value = link.href
+                      document.body.appendChild(Textarea)
+                      Textarea.focus()
+                      Textarea.select()
+                      try {
+                        let success = document.execCommand('copy')
+                        if (!success) {
+                          alert('could not copy to clipboard')
+                        }
+                      } catch (err) {
+                        console.log(err)
+                        alert(err)
+                      }
+                      document.body.removeChild(Textarea)
+                    }
+                  },
+                  title: "Copy Link to Clipboard"
+                }, '🔗'),
+                m('.Label', view.Propername),
+                m('a', {
+                  href: view.Entryname + '/' + view.Filename,
+                  title: "Download file"
+                }, '⬇')
+              ])
+            ]),
+            m("section.TabContent" + (view.isScaled ? (".Scaled" + (view.isZoomed ? ".ZoomedOut" : ".ZoomedIn")) : (view.isZoomed ? ".ZoomedIn" : ".ZoomedOut")),
+              {
+                oncreate: (vnode) => {
+                  view.TabContent = vnode.dom
+                }
+              },
+              [
+                view.Type === "image" ?
+                  m('.DataContainer' + (view.ImageZoom ? '.Zoomed' : ''), {
+                    style: "width: " + view.ImageWidth + "px;" +
+                          "height: " + view.ImageHeight + "px;" +
+                          "background-image: url(" + view.Entryname + "/" + view.Filename + ");",
+                    onclick: e => {
+                      e.preventDefault()
+                      view.isZoomed = !view.isZoomed
+                      view.calculateImageSize(view)
+                    }
+                  })
+                  : view.Type === "audio" ?
+                    m('.DataContainer',
+                      m('audio', {
+                        controls: true,
+                        src: view.Entryname + "/" + view.Filename,
+                      })
+                    )
+                    : view.Type === "video" ?
+                      m('.DataContainer',
+                        m('video', {
+                          controls: true,
+                        }, m('source', {
+                          src: view.Entryname + "/" + view.Filename,
+                          type: view.Mimetype,
+                        }))
+                      )
+                      : m('.DataContainer', m.trust(view.DataHTML))
+              ]),
+            m(StatusBar.Component)
+          ])
+        }
+      }
+    }
+  }
+}
+
+  const $ = {
+    letsGo: () => {
+      const container = document.getElementById("Container")
+      if (container.children[0].className == "View") {
+        const fpart = document.getElementById("Filename")
+        const Propername = fpart ? fpart.innerText : ''
+
         // First we retrieve the image reference
-        let img = document.getElementsByTagName("img")[0]
-        let audio = document.getElementsByTagName("audio")[0]
-        let video = document.getElementsByTagName("video")[0]
-        if (img) {
-          let parts = img.getAttribute('src').split('/')
-          View.Entryname = parts[0]
-          View.Filename = parts[1]
-          View.Type = "image"
-          View.HiddenImage.addEventListener('load', e => {
-            View.calculateImageSize()
+        const imgs = document.getElementsByTagName("img")
+        const audios = document.getElementsByTagName("audio")
+        const videos = document.getElementsByTagName("video")
+        for (const img of imgs) {
+          const parts = img.getAttribute('src').split('/')
+          const view = {
+            ...createView(),
+            Propername,
+            Entryname: parts[0],
+            Filename: parts[1],
+            Type: "image"
+          }
+          view.HiddenImage.addEventListener('load', e => {
+            view.calculateImageSize(view)
           })
           window.addEventListener('resize', e => {
-            View.calculateImageSize()
+            view.calculateImageSize(view)
           })
-          View.HiddenImage.src = parts.join('/')
-        } else if (audio) {
-          let parts = audio.getAttribute('src').split('/')
-          View.Entryname = parts[0]
-          View.Filename = parts[1]
-          View.Type = "audio"
-        } else if (video) {
-          let source = video.getElementsByTagName("source")[0]
-          if (source) {
-            let parts = source.getAttribute('src').split('/')
-            View.Entryname = parts[0]
-            View.Filename = parts[1]
-            View.Type = "video"
-            View.Mimetype = source.getAttribute('type')
+          view.HiddenImage.src = parts.join('/')
+          Views.push(view)
+        }
+        for (const audio of audios) {
+          const parts = audio.getAttribute('src').split('/')
+          const view = {
+            ...createView(),
+            Propername,
+            Entryname: parts[0],
+            Filename: parts[1],
+            Type: "audio"
           }
-        } else {
-          let target = document.getElementsByClassName("Label")[0]
+          Views.push(view)
+        }
+        for (const video of videos) {
+          const source = video.getElementsByTagName("source")[0]
+          if (source) {
+            const parts = source.getAttribute('src').split('/')
+            const view = {
+              ...createView,
+              Propername,
+              Entryname: parts[0],
+              Filename: parts[1],
+              Type: "video",
+              Mimetype: source.getAttribute('type')
+            }
+            Views.push(view)
+          }
+        }
+        if(!imgs && !audios && !videos) {
+          const target = document.getElementsByClassName("Label")[0]
           let a = target.getElementsByTagName("a")[0]
+          let view;
           if (a) {
             let parts = a.getAttribute('href').split('/')
-            View.Entryname = parts[0]
-            View.Filename = parts[1]
+            view = {
+              ...createView(),
+              Entryname: parts[0],
+              Filename: parts[1],
+            }
           }
-          View.DataHTML = document.getElementsByClassName("DataContainer")[0].innerText
+          view.DataHTML = document.getElementsByClassName("DataContainer")[0].innerText
+          Views.push(view);
         }
-        View.CreationTime = document.getElementById("StatusBar").innerHTML
-        m.mount(document.getElementById("Container"), View.Component)
-      } else if (target.children[0].className == "Upload") {
-        m.mount(document.getElementById("Container"), Main.Component)
+        // this.CreationTime = document.getElementById("StatusBar").innerHTML
+        for (const view of Views) {
+          m.mount(container, view.GetComponent(view))
+        }
+      } else if (container.children[0].className == "Upload") {
+        m.mount(container, Main.Component)
       }
     }
   }

--- a/static/shupload.js
+++ b/static/shupload.js
@@ -441,7 +441,7 @@ let shupload = (function () {
     }
   }
   let currentlyZoomed = false;
-  const createView = () => {
+  const createView = (solo) => {
     return {
       Filename: "",
       Entryname: "",
@@ -483,7 +483,7 @@ let shupload = (function () {
                     display: currentlyZoomed ? 'none': ''
                   }
                 }, [
-                  m('a', {
+                  solo ? m('a', {
                     href: `${view.Entryname}/${view.Filename}`,
                     onclick: (e) => {
                       e.preventDefault()
@@ -516,7 +516,7 @@ let shupload = (function () {
                       }
                     },
                     title: "Copy Link to Clipboard"
-                  }, '🔗'),
+                  }, '🔗') : null,
                   m('.Label', decodeURIComponent(view.Filename)),
                   m('a', {
                     href: view.Entryname + '/' + view.Filename,
@@ -574,7 +574,7 @@ let shupload = (function () {
         // First we retrieve the data items
         const dataItems = document.getElementsByClassName("DataItem")
         for (const item of dataItems) {
-          let view = createView();
+          let view = createView(len(dataItems)===1);
           const img = item.getElementsByTagName("img")[0]
           const audio = item.getElementsByTagName("audio")[0]
           const video = item.getElementsByTagName("video")[0]

--- a/static/style.css
+++ b/static/style.css
@@ -95,9 +95,6 @@ a {
 }
 #Main.View .TabContent.Scaled {
 }
-#Main.View .TabContent.Scaled.ZoomedIn .DataContainer {
-  position: static;
-}
 
 #Main.View .Tab {
   flex: 0;
@@ -106,9 +103,6 @@ a {
 Hacky stuff for CSS image click
 */
 .NoJS .DataContainer {
-  flex: 1;
-  display: flex;
-  flex-flow: row nowrap;
   cursor: zoom-in;
   -webkit-touch-callout: none;
   -webkit-user-select: none;
@@ -181,10 +175,6 @@ Hacky stuff for CSS image click
   align-items: center;
   justify-content: center;
   background-color: #111119;
-}
-.TabContent.NoJS {
-  align-items: stretch;
-  justify-content: stretch;
 }
 .TabContent * {
   z-index: 2;

--- a/static/style.css
+++ b/static/style.css
@@ -60,7 +60,6 @@ a {
   box-shadow: none;
 }
 #Main.View .TabContent {
-  height: 0
 }
 #Main.View .TabContent.ZoomedIn {
   height: auto;
@@ -71,7 +70,7 @@ a {
 }
 #Main.View .TabContent.ZoomedIn .DataContainer {
   flex: auto;
-  position: absolute;
+  z-index: 2;
   top: 0;
   left: 0;
   cursor: zoom-out;
@@ -80,6 +79,7 @@ a {
   background-position: center;
 }
 #Main.View .TabContent.ZoomedOut .DataContainer {
+  z-index: 0;
   cursor: zoom-in;
   background-size: contain;
   background-repeat: no-repeat;
@@ -122,6 +122,9 @@ Hacky stuff for CSS image click
   cursor: zoom-in;
 }
 .NoJS .DataContainer label input:checked ~ img {
+  position: absolute;
+  left: 0;
+  top: 0;
   object-fit: cover;
   width: auto;
   height: auto;
@@ -177,7 +180,6 @@ Hacky stuff for CSS image click
   background-color: #111119;
 }
 .TabContent * {
-  z-index: 2;
 }
 .TabContent::before {
   content: '';
@@ -252,6 +254,10 @@ Hacky stuff for CSS image click
 video {
   max-width: 100%;
   overflow: auto;
+  cursor: default;
+}
+audio {
+  cursor: default;
 }
 .Preview {
   margin: 0;

--- a/static/style.css
+++ b/static/style.css
@@ -71,8 +71,11 @@ a {
 #Main.View .TabContent.ZoomedIn .DataContainer {
   flex: auto;
   z-index: 2;
-  top: 0;
-  left: 0;
+  /* breaking gif zoom? 
+    position: absolute;
+    top: 0;
+    left: 0;
+  */
   cursor: zoom-out;
   background-size: contain;
   background-repeat: no-repeat;

--- a/templates/upload.tmpl
+++ b/templates/upload.tmpl
@@ -15,7 +15,7 @@
   <section id="Container">
     <section id="Main" class="Upload">
       <form class="TabContent" method="post" enctype="multipart/form-data">
-        <input type="file" name="file" accept="*" multiple>
+        <input type="file" name="file" accept="image/*" multiple>
         <button type="submit">Upload!</button>
       </form>
     </section>

--- a/templates/upload.tmpl
+++ b/templates/upload.tmpl
@@ -15,7 +15,7 @@
   <section id="Container">
     <section id="Main" class="Upload">
       <form class="TabContent" method="post" enctype="multipart/form-data">
-        <input type="file" name="file" accept="image/*">
+        <input type="file" name="file" accept="*" multiple>
         <button type="submit">Upload!</button>
       </form>
     </section>

--- a/templates/view.tmpl
+++ b/templates/view.tmpl
@@ -7,6 +7,7 @@
   <link rel="stylesheet" type="text/css" href="./static/style.css" />
   <link href="https://fonts.googleapis.com/css?family=ZCOOL+QingKe+HuangYou" rel="stylesheet">
   <script src="https://unpkg.com/mithril/mithril.js"></script>
+  <script type="text/javascript" src="./static/shupload.js"></script>
 </head>
 <body>
   <section id="Container">

--- a/templates/view.tmpl
+++ b/templates/view.tmpl
@@ -16,7 +16,7 @@
         <a href="./">
           <section class="Tab">↩</section>
         </a>
-        <div class="Label" style="flex: 1"><a href="{{.Entryname}}/{{.EscapedFilename}}">🔗</a>&nbsp;<span id="Filename">{{.Filename}}</span>&nbsp;<a href="{{.Entryname}}/{{.EscapedFilename}}">⬇</a></div>
+        <div class="Label" style="flex: 1"><a href="{{.Entryname}}">🔗</a>&nbsp;<span id="Filename">{{.Filename}}</span>&nbsp;<a href="{{.Entryname}}/{{.EscapedFilename}}">⬇</a></div>
       </section>
       <section class="TabContent NoJS">
         <div class="DataContainer">

--- a/templates/view.tmpl
+++ b/templates/view.tmpl
@@ -7,7 +7,6 @@
   <link rel="stylesheet" type="text/css" href="./static/style.css" />
   <link href="https://fonts.googleapis.com/css?family=ZCOOL+QingKe+HuangYou" rel="stylesheet">
   <script src="https://unpkg.com/mithril/mithril.js"></script>
-  <script type="text/javascript" src="./static/shupload.js"></script>
 </head>
 <body>
   <section id="Container">

--- a/templates/viewMultiple.tmpl
+++ b/templates/viewMultiple.tmpl
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>{{.Key}} - shupload</title>
+  <link rel="icon" type="image/png" href="./static/shupload-32x32.png" />
+  <link rel="stylesheet" type="text/css" href="./static/style.css" />
+  <link href="https://fonts.googleapis.com/css?family=ZCOOL+QingKe+HuangYou" rel="stylesheet">
+  <script src="https://unpkg.com/mithril/mithril.js"></script>
+  <script type="text/javascript" src="./static/shupload.js"></script>
+</head>
+<body>
+  <section id="Container">
+    <section id="Main" class="View">
+      <section class="Tabs">
+        <a href="./">
+          <section class="Tab">↩</section>
+        </a>
+      </section>
+      <section class="TabContent NoJS">
+      {{ range .Data }}
+      <div class="Label" style="flex: 1"><a href="{{.Entryname}}/{{.Filename}}">🔗</a>&nbsp;<span id="Filename">{{.Filename}}</span>&nbsp;<a href="{{.Entryname}}/{{.Filename}}">⬇</a></div>
+        <div class="DataContainer">
+          {{if or (eq .Filename "blob") (regexMatch "image/.*" .Mimetype) }}
+            <label>
+              <input type="checkbox">
+              <img src="{{.URI}}">
+            </label>
+          {{else if regexMatch "audio/.*" .Mimetype}}
+            <audio controls src="{{.URI}}">
+              Your browser does not support the <code>audio</code> element.
+            </audio>
+          {{else if regexMatch "video/.*" .Mimetype}}
+            <video controls>
+              <source src="{{.URI}}" type={{.Mimetype}}>
+              Your browser does not support the <code>video</code> element.
+            </video>
+          {{end}}
+        </div>
+      {{ end }}
+      </section>
+      <div id="StatusBar">
+        {{.CreationTime}}
+      </div>
+    </section>
+  </section>
+  <small id="Footer"><a href="https://github.com/kettek/shupload">shupload</a> copyright © 2018-2019 <a href="https://kettek.net">Ketchetwahmeegwun T. Southall</a>. Licensed under the <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GPLv3</a></small>
+</body>
+</html>

--- a/templates/viewMultiple.tmpl
+++ b/templates/viewMultiple.tmpl
@@ -16,11 +16,12 @@
         <a href="./">
           <section class="Tab">↩</section>
         </a>
+        <div class="Label" style="flex: 1"><a href="{{.Key}}">🔗</a>&nbsp;<span id="Filename">{{len .Files}} Files</span>&nbsp;<a style="opacity: 0.5; cursor: not-allowed">⬇</a></div>
       </section>
       <section class="TabContent NoJS">
       {{range .Files}}
       <div class="DataItem" id="{{.Entryname}}/{{.Filename}}">
-        <div class="Label"><a href="{{.Entryname}}/{{.EscapedFilename}}">🔗</a>&nbsp;<span id="Filename">{{.Filename}}</span>&nbsp;<a href="{{.Entryname}}/{{.EscapedFilename}}">⬇</a></div>
+        <div class="Label">&nbsp;<span id="Filename">{{.Filename}}</span>&nbsp;<a href="{{.Entryname}}/{{.EscapedFilename}}">⬇</a></div>
         <div class="DataContainer">
           {{if or (eq .Filename "blob") (regexMatch "image/.*" .Mimetype) }}
             <label>

--- a/templates/viewMultiple.tmpl
+++ b/templates/viewMultiple.tmpl
@@ -7,6 +7,7 @@
   <link rel="stylesheet" type="text/css" href="./static/style.css" />
   <link href="https://fonts.googleapis.com/css?family=ZCOOL+QingKe+HuangYou" rel="stylesheet">
   <script src="https://unpkg.com/mithril/mithril.js"></script>
+  <script type="text/javascript" src="./static/shupload.js"></script>
 </head>
 <body>
   <section id="Container">
@@ -18,7 +19,8 @@
       </section>
       <section class="TabContent NoJS">
       {{range .Files}}
-      <div class="Label"><a href="{{.Entryname}}/{{.Filename}}">🔗</a>&nbsp;<span id="Filename">{{.Filename}}</span>&nbsp;<a href="{{.Entryname}}/{{.Filename}}">⬇</a></div>
+      <div class="DataItem" id="{{.Entryname}}/{{.Filename}}">
+        <div class="Label"><a href="{{.Entryname}}/{{.Filename}}">🔗</a>&nbsp;<span id="Filename">{{.Filename}}</span>&nbsp;<a href="{{.Entryname}}/{{.Filename}}">⬇</a></div>
         <div class="DataContainer">
           {{if or (eq .Filename "blob") (regexMatch "image/.*" .Mimetype) }}
             <label>
@@ -36,6 +38,7 @@
             </video>
           {{end}}
         </div>
+      </div>
       {{ end }}
       </section>
       <div id="StatusBar">

--- a/templates/viewMultiple.tmpl
+++ b/templates/viewMultiple.tmpl
@@ -18,8 +18,8 @@
         </a>
       </section>
       <section class="TabContent NoJS">
-      {{ range .Data }}
-      <div class="Label" style="flex: 1"><a href="{{.Entryname}}/{{.Filename}}">🔗</a>&nbsp;<span id="Filename">{{.Filename}}</span>&nbsp;<a href="{{.Entryname}}/{{.Filename}}">⬇</a></div>
+      {{range .Files}}
+      <div class="Label"><a href="{{.Entryname}}/{{.Filename}}">🔗</a>&nbsp;<span id="Filename">{{.Filename}}</span>&nbsp;<a href="{{.Entryname}}/{{.Filename}}">⬇</a></div>
         <div class="DataContainer">
           {{if or (eq .Filename "blob") (regexMatch "image/.*" .Mimetype) }}
             <label>

--- a/templates/viewMultiple.tmpl
+++ b/templates/viewMultiple.tmpl
@@ -7,7 +7,6 @@
   <link rel="stylesheet" type="text/css" href="./static/style.css" />
   <link href="https://fonts.googleapis.com/css?family=ZCOOL+QingKe+HuangYou" rel="stylesheet">
   <script src="https://unpkg.com/mithril/mithril.js"></script>
-  <script type="text/javascript" src="./static/shupload.js"></script>
 </head>
 <body>
   <section id="Container">


### PR DESCRIPTION
This PR enhances shupload to support uploading and viewing multiple files at a time.
Multiple files can now be selected in the upload window, manually dropped onto the upload screen, or pasted into the clipboard section.

Still needs a bit of CSS lovin'. 
 - Looks like the TabContent class is used on both the parent tab holding all the items, as well as on each individual item, causing lil background to show when manually zooming browser out
![image](https://user-images.githubusercontent.com/19158752/152704846-5e826ee0-fc06-4bf5-9a25-d31a3ed70869.png)
 - Setting `position: absolute` breaks clicking on gifs to zoom them in, however it does allow scrolling to view images larger than the window size
