### PR TITLE
Remove `accept` type and fix Chrome video scrubbing

### DIFF
--- a/src/ViewHandler.go
+++ b/src/ViewHandler.go
@@ -20,14 +20,12 @@ package main
 
 import (
 	"html/template"
-	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
 	"path"
 	"regexp"
-	"strconv"
 )
 
 type ViewHandler struct {
@@ -92,21 +90,7 @@ func (h *ViewHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 				http.Error(res, "Data file missing", http.StatusInternalServerError)
 				return
 			}
-			// Get our length
-			length, err := data.Seek(0, io.SeekEnd)
-			if err != nil {
-				http.Error(res, "Error while seeking to end of data", http.StatusInternalServerError)
-				return
-			}
-			_, err = data.Seek(0, 0)
-			if err != nil {
-				http.Error(res, "Error while seeking to start of data", http.StatusInternalServerError)
-				return
-			}
-			res.Header().Set("Content-Disposition", "attachment; filename="+filename)
-			res.Header().Set("Content-Type", entry.Mimetype)
-			res.Header().Set("Content-Length", strconv.FormatInt(length, 10))
-			io.Copy(res, data)
+			http.ServeContent(res, req, filename, entry.CreationTime, data)
 		}
 	}
 

--- a/static/shupload.js
+++ b/static/shupload.js
@@ -41,7 +41,6 @@ let shupload = (function () {
   function selectFile() {
     let inp = document.createElement('input')
     inp.setAttribute('type', 'file')
-    inp.setAttribute('accept', 'image/*')
     inp.multiple = true
     inp.style = "display:none";
     inp.addEventListener('change', (e) => {

--- a/templates/upload.tmpl
+++ b/templates/upload.tmpl
@@ -15,7 +15,7 @@
   <section id="Container">
     <section id="Main" class="Upload">
       <form class="TabContent" method="post" enctype="multipart/form-data">
-        <input type="file" name="file" accept="image/*" multiple>
+        <input type="file" name="file" multiple>
         <button type="submit">Upload!</button>
       </form>
     </section>


### PR DESCRIPTION
Swaps out `io.Copy` with `http.ServeContent` to allow serving partial content which fixes video scrubbing in Chrome.
Also removes the `accept` type as I found it to be annoying to manually select `any` when prompted with Windows' file picker.